### PR TITLE
Support HTTP 301s

### DIFF
--- a/server.coffee
+++ b/server.coffee
@@ -10,6 +10,7 @@ excluded        = process.env.CAMO_HOST_EXCLUSIONS || '*.example.org'
 shared_key      = process.env.CAMO_KEY             || '0x24FEEDFACEDEADBEEFCAFE'
 camo_hostname   = process.env.CAMO_HOSTNAME        || "unknown"
 logging_enabled = process.env.CAMO_LOGGING_ENABLED || "disabled"
+max_redirects = process.env.CAMO_MAX_REDIRECTS     || 10;
 
 log = (msg) ->
   unless logging_enabled == "disabled"
@@ -33,6 +34,80 @@ finish = (resp, str) ->
   current_connections -= 1
   current_connections  = 0 if current_connections < 1
   resp.connection && resp.end str
+
+process_url = (url, transferred_headers, resp, remaining_redirects) ->
+  if url.host? && !url.host.match(RESTRICTED_IPS)
+    if url.host.match(EXCLUDED_HOSTS)
+      return four_oh_four(resp, "Hitting excluded hostnames")
+
+    src = Http.createClient url.port || 80, url.hostname
+
+    src.on 'error', (error) ->
+      four_oh_four(resp, "Client Request error #{error.stack}")
+
+    query_path = url.pathname
+    if url.query?
+      query_path += "?#{url.query}"
+
+    transferred_headers.host = url.host
+
+    log transferred_headers
+
+    srcReq = src.request 'GET', query_path, transferred_headers
+
+    srcReq.on 'response', (srcResp) ->
+      is_finished = true;
+
+      log srcResp.headers
+
+      content_length = srcResp.headers['content-length']
+
+      if content_length > 5242880
+        four_oh_four(resp, "Content-Length exceeded");
+      else
+        newHeaders =
+            'expires'                   : srcResp.headers['expires']
+            'content-type'              : srcResp.headers['content-type']
+            'cache-control'             : srcResp.headers['cache-control']
+            'content-length'            : content_length
+            'Camo-Host'                 : camo_hostname
+            'X-Content-Type-Options'    : 'nosniff'
+
+        if srcResp.headers['content-encoding']
+          newHeaders['content-encoding'] = srcResp.headers['content-encoding']
+
+        srcResp.on 'end', ->
+          if is_finished
+            finish resp
+        srcResp.on 'error', ->
+          if is_finished
+            finish resp
+        switch srcResp.statusCode
+          when 200
+            if newHeaders['content-type'] && newHeaders['content-type'].slice(0, 5) != 'image'
+              four_oh_four(resp, "Non-Image content-type returned")
+
+            log newHeaders
+
+            resp.writeHead srcResp.statusCode, newHeaders
+            srcResp.on 'data', (chunk) ->
+              resp.write chunk
+          when 301
+            if remaining_redirects <= 0
+              four_oh_four(resp, "Exceeded max depth")
+            is_finished = false;
+            url = Url.parse srcResp.headers['location']
+            process_url url, transferred_headers, resp, remaining_redirects - 1
+          when 304
+            resp.writeHead srcResp.statusCode, newHeaders
+          else
+            four_oh_four(resp, "Responded with " + srcResp.statusCode + ":" + srcResp.headers)
+    srcReq.on 'error', ->
+      finish resp
+
+    srcReq.end();
+  else
+    four_oh_four(resp, "No host found " + url.host)
 
 # decode a string of two char hex digits
 hexdec = (str) ->
@@ -91,74 +166,7 @@ server = Http.createServer (req, resp) ->
       if hmac_digest == query_digest
         url = Url.parse dest_url
 
-        if url.host? && !url.host.match(RESTRICTED_IPS)
-          if url.host.match(EXCLUDED_HOSTS)
-            return four_oh_four(resp, "Hitting excluded hostnames")
-
-          src = Http.createClient url.port || 80, url.hostname
-
-          src.on 'error', (error) ->
-            four_oh_four(resp, "Client Request error #{error.stack}")
-
-          query_path = url.pathname
-          if url.query?
-            query_path += "?#{url.query}"
-
-          transferred_headers.host = url.host
-
-          log transferred_headers
-
-          srcReq = src.request 'GET', query_path, transferred_headers
-
-          srcReq.on 'response', (srcResp) ->
-            log srcResp.headers
-
-            content_length  = srcResp.headers['content-length']
-
-            if content_length > 5242880
-              four_oh_four(resp, "Content-Length exceeded")
-            else
-              newHeaders =
-                'expires'                : srcResp.headers['expires']
-                'content-type'           : srcResp.headers['content-type']
-                'cache-control'          : srcResp.headers['cache-control']
-                'content-length'         : content_length
-                'Camo-Host'              : camo_hostname
-                'X-Content-Type-Options' : 'nosniff'
-                
-              if srcResp.headers['content-encoding']
-                newHeaders['content-encoding'] = srcResp.headers['content-encoding']
-                
-              srcResp.on 'end', ->
-                finish resp
-
-              srcResp.on 'error', ->
-                finish resp
-
-              switch srcResp.statusCode
-                when 200
-                  if newHeaders['content-type'] && newHeaders['content-type'].slice(0, 5) != 'image'
-                    four_oh_four(resp, "Non-Image content-type returned")
-
-                  log newHeaders
-
-                  resp.writeHead srcResp.statusCode, newHeaders
-                  srcResp.on 'data', (chunk) ->
-                    resp.write chunk
-
-                when 304
-                  resp.writeHead srcResp.statusCode, newHeaders
-
-                else
-                  four_oh_four(resp, "Responded with #{srcResp.statusCode}:#{srcResp.headers}")
-
-          srcReq.on 'error', ->
-            finish resp
-
-          srcReq.end()
-
-        else
-          four_oh_four(resp, "No host found #{url.host}")
+        process_url url, transferred_headers, resp, max_redirects
       else
         four_oh_four(resp, "checksum mismatch #{hmac_digest}:#{query_digest}")
     else


### PR DESCRIPTION
We've noticed that some of our users are linking to urls that return 301 instead of 200.

I've refactored the url fetching code into a function named process_url (open to renaming).
Much of this refactor involves making sure the scopes for variables are correct across the nested closures.

Added a missing return 404 for image content-type not being an image.

For 301s, a recursive call to process_url is made with a default max depth of 10.
