### PR TITLE
Fix chunked encoding test

### DIFF
--- a/test/proxy_test.rb
+++ b/test/proxy_test.rb
@@ -32,6 +32,7 @@ module CamoProxyTests
   def test_proxy_valid_chunked_image_file
     response = request('http://www.igvita.com/posts/12/spdyproxy-diagram.png')
     assert_equal(200, response.code)
+    assert_nil(response.headers[:content_length])
   end
 
   def test_follows_redirects


### PR DESCRIPTION
The chunked bug was that, even though we were sending 200 HTTP OK,
we were setting the content-length header to 'undefined'. I guess
most http clients, including curl, don't deal with this very well.

Anyway, we should make sure we don't do that in the test.
