### PR TITLE
Added code to stop Camo from requesting from itself.

### DIFF
--- a/server.coffee
+++ b/server.coffee
@@ -169,6 +169,9 @@ server = Http.createServer (req, resp) ->
       digest:   query_digest
     })
 
+    if req.headers['via'] && req.headers['via'].indexOf(user_agent) != -1
+      return four_oh_four(resp, "Requesting from self")
+
     if url.pathname? && dest_url
       hmac = Crypto.createHmac("sha1", shared_key)
       hmac.update(dest_url)

--- a/test/proxy_test.rb
+++ b/test/proxy_test.rb
@@ -117,6 +117,13 @@ module CamoProxyTests
     response = request('http://d.pr/i/rr7F+')
     assert_equal(200, response.code)
   end
+
+  def test_request_from_self
+    assert_raise RestClient::ResourceNotFound do
+      uri = request_uri("#{config['host']}/favicon.ico")
+      response = request( uri )
+    end
+  end
 end
 
 class CamoProxyQueryStringTest < Test::Unit::TestCase


### PR DESCRIPTION
This can happen if hacker forces Camo to request from itself, such as encoding the URL multiple times, or using a 302 to redirects back on itself. This causes Camo to spin up a new connection and enter a loop until it runs out of memory.
