### PR TITLE
URI Encode dest_url.

### DIFF
--- a/server.coffee
+++ b/server.coffee
@@ -160,7 +160,7 @@ server = Http.createServer (req, resp) ->
     else
       url_type = 'query'
       dest_url = QueryString.parse(url.query).url
-
+    
     log({
       type:     url_type
       url:      req.url
@@ -179,6 +179,7 @@ server = Http.createServer (req, resp) ->
       hmac_digest = hmac.digest('hex')
 
       if hmac_digest == query_digest
+        dest_url = encodeURI(decodeURI(dest_url))
         url = Url.parse dest_url
 
         process_url url, transferred_headers, resp, max_redirects

--- a/server.js
+++ b/server.js
@@ -210,6 +210,7 @@
         hmac.update(dest_url);
         hmac_digest = hmac.digest('hex');
         if (hmac_digest === query_digest) {
+          dest_url = encodeURI(decodeURI(dest_url));
           url = Url.parse(dest_url);
           return process_url(url, transferred_headers, resp, max_redirects);
         } else {


### PR DESCRIPTION
Ran into an issue with this URL "http://www.alesunlimited.com/public/ales/800/Knee Deep Hop Shortage Triple IPA.jpg"

Just wanted to check if this is something you think should be in camo, or if the url encoding should be done when the camo url is generated i.e. inside html-pipeline.
