### PR TITLE
Add fallback for Accept header.

### DIFF
--- a/server.coffee
+++ b/server.coffee
@@ -146,7 +146,7 @@ server = Http.createServer (req, resp) ->
     transferred_headers =
       'Via'                    : user_agent
       'User-Agent'             : user_agent
-      'Accept'                 : req.headers.accept ? '*/*'
+      'Accept'                 : req.headers.accept ? 'image/*'
       'Accept-Encoding'        : req.headers['accept-encoding']
       'x-forwarded-for'        : req.headers['x-forwarded-for']
       'x-content-type-options' : 'nosniff'

--- a/server.js
+++ b/server.js
@@ -181,7 +181,7 @@
       transferred_headers = {
         'Via': user_agent,
         'User-Agent': user_agent,
-        'Accept': (_ref = req.headers.accept) != null ? _ref : '*/*',
+        'Accept': (_ref = req.headers.accept) != null ? _ref : 'image/*',
         'Accept-Encoding': req.headers['accept-encoding'],
         'x-forwarded-for': req.headers['x-forwarded-for'],
         'x-content-type-options': 'nosniff'


### PR DESCRIPTION
CloudFront does not appear to forward Accept headers. Without an Accept header, camo sends `Accept: undefined`.

I ran into an issue with this when requesting an image from an IIS server:

```
curl -v --header 'Accept: undefined' http://images.anandtech.com/doci/6673/OpenMoboAMD30_575px.png
* About to connect() to images.anandtech.com port 80 (#0)
*   Trying 199.19.80.14...
* connected
* Connected to images.anandtech.com (199.19.80.14) port 80 (#0)
> GET /doci/6673/OpenMoboAMD30_575px.png HTTP/1.1
> User-Agent: curl/7.24.0 (x86_64-apple-darwin12.0) libcurl/7.24.0 OpenSSL/0.9.8r zlib/1.2.5
> Host: images.anandtech.com
> Accept: undefined
> 
< HTTP/1.1 406 Not Acceptable
< Content-Type: text/html
< Server: Microsoft-IIS/7.5
< X-Powered-By: ASP.NET
< Date: Sat, 19 Jan 2013 10:27:15 GMT
< Content-Length: 1346
< 
```
