### PR TITLE
Don't write a PID file in `pwd`/tmp/

### DIFF
--- a/server.coffee
+++ b/server.coffee
@@ -191,7 +191,4 @@ server = Http.createServer (req, resp) ->
 console.log "SSL-Proxy running on #{port} with pid:#{process.pid}."
 console.log "Using the secret key #{shared_key}"
 
-Fs.open "tmp/camo.pid", "w", 0o600, (err, fd) ->
-  Fs.writeSync fd, process.pid
-
 server.listen port

--- a/server.js
+++ b/server.js
@@ -225,10 +225,6 @@
 
   console.log("Using the secret key " + shared_key);
 
-  Fs.open("tmp/camo.pid", "w", 0x180, function(err, fd) {
-    return Fs.writeSync(fd, process.pid);
-  });
-
   server.listen(port);
 
 }).call(this);


### PR DESCRIPTION
If `camo` is running as a privileged user the current behaviour would allow a race condition leading to the overwriting of arbitrary files.

This is exploitable when running `camo` from an init script, since then your process as a working directory of `/`.

Since `camo` does not fork into the background there isn't really a reason to write its PID out to a file; people writing initscripts can simply use `start-stop-daemon`'s `--make-pidfile` flag.
