### PR TITLE
Use UTF-8 encoding so client and server HMAC agree.

### DIFF
--- a/server.coffee
+++ b/server.coffee
@@ -175,7 +175,7 @@ server = Http.createServer (req, resp) ->
 
     if url.pathname? && dest_url
       hmac = Crypto.createHmac("sha1", shared_key)
-      hmac.update(dest_url)
+      hmac.update(dest_url, 'utf8')
 
       hmac_digest = hmac.digest('hex')
 

--- a/server.js
+++ b/server.js
@@ -207,7 +207,7 @@
       }
       if ((url.pathname != null) && dest_url) {
         hmac = Crypto.createHmac("sha1", shared_key);
-        hmac.update(dest_url);
+        hmac.update(dest_url, 'utf8');
         hmac_digest = hmac.digest('hex');
         if (hmac_digest === query_digest) {
           url = Url.parse(dest_url);


### PR DESCRIPTION
Currently URLs with special characters result in a checksum mismatch. This fixes that.

Client: 

``` irb
irb(main):001:0> require 'openssl'
irb(main):002:0> OpenSSL::HMAC.hexdigest(OpenSSL::Digest::Digest.new('sha1'), '123', '©')
=> "9f4be406ec0626d575a2a5eb15645d58483de843"
```

Server without utf8

``` javascript
Crypto = require('crypto');
hmac = Crypto.createHmac("sha1", '123');
hmac.update('©');
hmac.digest('hex');
// '517e495e02bcb52e6d3d02db389c457520b6c59f'
```

Server with utf8

``` javascript
Crypto = require('crypto');
hmac = Crypto.createHmac("sha1", '123');
hmac.update('©', 'utf8');
hmac.digest('hex');
// '9f4be406ec0626d575a2a5eb15645d58483de843'
```

For example this image will be broken: `http://dl.dropboxusercontent.com/u/16657547/©.jpeg`

<img src="http://dl.dropboxusercontent.com/u/16657547/©.jpeg" />

But not proxied through camo it shows up:

<img src="https://dl.dropboxusercontent.com/u/16657547/©.jpeg" />
