### PR TITLE
Switch engines.node semver operator

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,6 @@
   "dependencies": {
   },
   "engines": {
-    "node": ">=0.10.0"
+    "node": "^0.10.0"
   }
 }


### PR DESCRIPTION
Avoids warnings from Heroku:

```
PRO TIP: Avoid using semver ranges starting with '>' in engines.node 
See https://devcenter.heroku.com/articles/nodejs-support 
```

See https://github.com/isaacs/node-semver#ranges
