### PR TITLE
Fix failing test_proxy_localhost_test_server

### DIFF
--- a/test/servers/ok.ru
+++ b/test/servers/ok.ru
@@ -1,5 +1,5 @@
 run lambda { |env|
   path = File.expand_path('../octocat.jpg', __FILE__)
   data = File.read(path)
-  [200, {'Content-Type' => 'image/jpg'}, [data]]
+  [200, {'Content-Type' => 'image/jpeg'}, [data]]
 }


### PR DESCRIPTION
The test server was using the content-type 'image/jpg'. The correct
mime type for JPEG images and the mime type defined in mime-types.json
is 'image/jpeg'.
