### PR TITLE
Add explicit radix to parseInt() for setting the port.

### DIFF
--- a/server.coffee
+++ b/server.coffee
@@ -7,7 +7,7 @@ Https       = require 'https'
 Crypto      = require 'crypto'
 QueryString = require 'querystring'
 
-port            = parseInt process.env.PORT        || 8081
+port            = parseInt process.env.PORT        || 8081, 10
 version         = require(Path.resolve(__dirname, "package.json")).version
 shared_key      = process.env.CAMO_KEY             || '0x24FEEDFACEDEADBEEFCAFE'
 max_redirects   = process.env.CAMO_MAX_REDIRECTS   || 4

--- a/server.js
+++ b/server.js
@@ -19,7 +19,7 @@
 
   QueryString = require('querystring');
 
-  port = parseInt(process.env.PORT || 8081);
+  port = parseInt(process.env.PORT || 8081, 10);
 
   version = require(Path.resolve(__dirname, "package.json")).version;
 


### PR DESCRIPTION
JavaScript does some "interesting" auto-detection of the radix of the
integer being parsed. Since the port is always base 10, statically set
the radix to fix a jslint warning.
