### PR TITLE
Change URL of failing test_follows_temporary_redirects

### DIFF
--- a/test/proxy_test.rb
+++ b/test/proxy_test.rb
@@ -193,7 +193,7 @@ module CamoProxyTests
   end
 
   def test_follows_temporary_redirects
-    response = request('http://d.pr/i/rr7F+')
+    response = request('http://bit.ly/1l9Fztb')
     assert_equal(200, response.code)
   end
 


### PR DESCRIPTION
Droplr URL was redirecting to a 404 page so test was failing. Updated it with a bitly URL that redirects to http://placehold.it/300x200
