### PR TITLE
Update url for Heroku Button

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Using a shared key, proxy URLs are encrypted with [hmac](http://en.wikipedia.org
 
 Camo currently runs on node version 0.10.26 at GitHub on [heroku](http://heroku.com).
 
-[![Launch on Heroku](https://www.herokucdn.com/deploy/button.png)](https://dashboard-next.heroku.com/new?template=https://github.com/atmos/camo)
+[![Launch on Heroku](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy?template=https://github.com/atmos/camo)
 
 Features
 --------


### PR DESCRIPTION
dashboard-next.heroku.com is in beta right now, and it'll be a replacement of the existing dashboard.heroku.com. When that happens, you'll might need to update that url.

Updating it to www.heroku.com/deploy, it'll redirect to the proper place anytime, so no update will be needed!

And thanks for using it!!!

:metal:
