### PR TITLE
Don't require path twice

### DIFF
--- a/server.coffee
+++ b/server.coffee
@@ -1,7 +1,6 @@
 Fs          = require 'fs'
 Path        = require 'path'
 Url         = require 'url'
-Path        = require 'path'
 Http        = require 'http'
 Https       = require 'https'
 Crypto      = require 'crypto'


### PR DESCRIPTION
Don't require `path` twice.
