### PR TITLE
Add links to examples in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,3 +81,7 @@ To enable useful line numbers in stacktraces you probably want to compile the se
 
     % coffee -c server.coffee
     % /usr/bin/env PORT=9090 CAMO_KEY="<my application key>" node server.js
+
+## Examples
+* Ruby - https://github.com/ankane/camo
+* PHP - https://github.com/willwashburn/Phpamo


### PR DESCRIPTION
I'm thinking it could be useful having a running list of clients for creating the urls in the readme. Something like this would have helped me when I first started/setup camo.