### PR TITLE
bump version to 2.3.0 -- upgrade to coffeescript 1.9.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "camo",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "dependencies": {
   },
   "engines": {


### PR DESCRIPTION
Follow up to - https://github.com/atmos/camo/pull/80

Upgraded to Coffeescript 1.9.2, recompiled and didn't detect any changes other than the changes that were made in the PR above.