### PR TITLE
Run as user nobody inside of the docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,5 +11,6 @@ RUN npm install
 ADD server.js /app/
 ADD mime-types.json /app/
 
-expose 8081
+EXPOSE 8081
+USER nobody
 CMD nodejs server.js


### PR DESCRIPTION
This is a simple PR

It makes nodejs run as user nobody inside of the docker container.
Previously it was root.

