### PR TITLE
Rm unnecessary data for saving size of image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,11 @@ FROM ubuntu
 
 WORKDIR /app
 
-RUN apt-get update && apt-get install -yq nodejs npm
+RUN apt-get update && \
+    apt-get install -yq \
+        nodejs \
+        npm && \
+    rm -rf /var/lib/apt/lists/*
 
 ADD package.json /app/
 RUN npm install

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,8 @@
 FROM ubuntu
 
-RUN apt-get update && apt-get install -yq nodejs npm
-
-RUN mkdir /app
 WORKDIR /app
+
+RUN apt-get update && apt-get install -yq nodejs npm
 
 ADD package.json /app/
 RUN npm install


### PR DESCRIPTION
I removed unnecessary data made by apt-get.
Because, it can save size of docker image.

```
$ docker images
REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
before             latest              5e0459e16841        26 minutes ago      446.9 MB
after              latest              367461947f53        21 minutes ago      409.3 MB
```