### PR TITLE
Explain the node TLS rejection option in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Camo is configured through environment variables.
 * `CAMO_TIMING_ALLOW_ORIGIN`: The string for Camo to include in the [`Timing-Allow-Origin` header](http://www.w3.org/TR/resource-timing/#cross-origin-resources) it sends in responses to clients. The header is omitted if this environment variable is not set. (default: not set)
 * `CAMO_HOSTNAME`: The `Camo-Host` header value that Camo will send. (default: `unknown`)
 * `CAMO_KEEP_ALIVE`: Whether or not to enable keep-alive session. (default: `false`)
+* `NODE_TLS_REJECT_UNAUTHORIZED`: If set to `0`, camo will also forward images from hosts with a bad SSL implementation. (default: `1`)
 
 ## Testing Functionality
 


### PR DESCRIPTION
Since we use camo to proxy all of our image requests, we have learned in the process there are a _lot_ of awful SSL implementations out there. Browsers accept these, but NodeJS rejects these connections.

An example is a client provided image as `https://itmasters2016.nl/images/ITMasters_Logo_2016.png`. Your browser will render it fine, but it would be blocked by Camo.

![bad SSL](https://itmasters2016.nl/images/ITMasters_Logo_2016.png)

Apparently Githubs camo implementation does not like the image either.

This PR explains how to "ignore" those errors