### PR TITLE
Upgrade to Node.js v6.11.1 LTS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
-- 2.1.0
+- 2.3.4
 gemfile: test.gemfile
 before_install:
 - npm install -g coffee-script

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.3.0",
   "dependencies": {},
   "engines": {
-    "node": "^0.10.29"
+    "node": "^6.11.1"
   },
   "devDependencies": {
     "coffee-script": "^1.12.6"

--- a/test.gemfile.lock
+++ b/test.gemfile.lock
@@ -4,7 +4,7 @@ GEM
     addressable (2.3.4)
     mime-types (1.23)
     power_assert (0.2.2)
-    rack (1.5.2)
+    rack (2.0.3)
     rest-client (1.6.7)
       mime-types (>= 1.16)
     test-unit (3.0.8)
@@ -18,3 +18,6 @@ DEPENDENCIES
   rack
   rest-client (~> 1.3)
   test-unit
+
+BUNDLED WITH
+   1.14.6


### PR DESCRIPTION
This builds upon PR #123 and closes #122.

* Upgraded rack dependency to prevent `Content-Length` headers returning alongside `Transfer-Encoding` headers in tests.
* Upgraded to Node.js v6.11.1 LTS thereby taking care of CVE-2017-1000381