### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,4 @@
-FROM ubuntu
-
-RUN apt-get update && apt-get install -yq nodejs npm
+FROM node:8.4
 
 RUN mkdir /app
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,14 @@
 FROM node:8.4
 
-RUN mkdir /app
-WORKDIR /app
+RUN mkdir -p /opt/camo/
+WORKDIR /opt/camo/
 
-ADD package.json /app/
-RUN npm install
-
-ADD server.js /app/
-ADD mime-types.json /app/
+ADD package.json /opt/camo/
+ADD server.js /opt/camo/
+ADD mime-types.json /opt/camo/
 
 EXPOSE 8081
+
+RUN npm install
 USER nobody
-CMD nodejs server.js
+CMD ["npm", "start"]


### PR DESCRIPTION
There is no need to use a redundant Ubuntu container when official node.js containers with up-to-date npm installations already exist. Using the Ubuntu image only adds unnecessary overhead. :)