### PR TITLE
Update PORT variable to CAMO_PORT

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ that the resulting value includes only characters `[0-9a-f]`.
 
 Camo is configured through environment variables.
 
-* `PORT`: The port number Camo should listen on. (default: 8081)
+* `CAMO_PORT`: The port number Camo should listen on. (default: 8081)
 * `CAMO_HEADER_VIA`: The string for Camo to include in the `Via` and `User-Agent` headers it sends in requests to origin servers. (default: `Camo Asset Proxy <version>`)
 * `CAMO_KEY`: A shared key consisting of a random string, used to generate the HMAC digest.
 * `CAMO_LENGTH_LIMIT`: The maximum `Content-Length` Camo will proxy. (default: 5242880)

--- a/server.js
+++ b/server.js
@@ -17,7 +17,7 @@
 
   QueryString = require('querystring');
 
-  port = parseInt(process.env.PORT || 8081, 10);
+  port = parseInt(process.env.CAMO_PORT || 8081, 10);
 
   version = require(Path.resolve(__dirname, "package.json")).version;
 


### PR DESCRIPTION
There are many different applications which could be trying to use an environment variable simply named 'PORT'. Since all of the other possible Camo variables are already prefixed with "CAMO_" I felt that this should match with the others too. Tested this change within a production environment using Docker.