### PR TITLE
Bump node version to the latest LTS version

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.3.0",
   "dependencies": {},
   "engines": {
-    "node": "^6.11.1"
+    "node": "^6.11.4"
   },
   "devDependencies": {
     "coffee-script": "^1.12.6"


### PR DESCRIPTION
v6.11.4 is now the latest Node LTS version