### PR TITLE
Bump node version to the latest LTS version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8.4
+FROM node:8.9
 
 RUN mkdir -p /opt/camo/
 WORKDIR /opt/camo/

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.3.0",
   "dependencies": {},
   "engines": {
-    "node": "^6.11.1"
+    "node": "^8.9.0"
   },
   "devDependencies": {
     "coffee-script": "^1.12.6"


### PR DESCRIPTION
[v8.9.0 is now the latest Node LTS version](https://nodejs.org/en/blog/release/v8.9.0/)

https://medium.com/the-node-js-collection/news-node-js-8-moves-into-long-term-support-and-node-js-9-becomes-the-new-current-release-line-74cf754a10a0