### PR TITLE
fix the docker command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ A `Dockerfile` is included, you can build and run it with:
 
 ```bash
 docker build -t camo .
-docker run --env CAMO_KEY=YOUR_KEY -t camo
+docker run -p 8081:8081 --env CAMO_KEY=YOUR_KEY -t camo
 ```
 
 ## Examples


### PR DESCRIPTION
In the readme's current docker command, cannot try camo because it has not assigned container ports to the host.
I think it is necessary to assign the port of the container to the host using the -p option.